### PR TITLE
Bugfix:  double quotation marks are needed or paths with spaces will …

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function getVideoInfo (video) {
     if (!(yield exists(video)))
       throw new Error(`${video} is not a valid path`)
 
-    var out = yield exec(`${ffprobe} -v quiet -print_format json -show_format -show_streams ${video}`)
+    var out = yield exec(`${ffprobe} -v quiet -print_format json -show_format -show_streams "${video}"`)
     return JSON.parse(out[0])
   })
 }


### PR DESCRIPTION
…not work

![image](https://user-images.githubusercontent.com/21686759/178163613-c8911b85-2a80-44f7-8f2d-dded5c8310a2.png)
(Simple example)

Double quotation is needed in the call to exe